### PR TITLE
Fix review&inquiry pop-up css & reassign image directory(#83)

### DIFF
--- a/client/css/include/inquiry_popup.css
+++ b/client/css/include/inquiry_popup.css
@@ -11,7 +11,7 @@
   justify-content: center;
   display:none;
   background: rgba(0, 0, 0, 0.5);
-  z-index:99;
+  z-index:600;
   position:fixed;
 }
 

--- a/client/css/include/review_popup.css
+++ b/client/css/include/review_popup.css
@@ -11,7 +11,7 @@
   justify-content: center;
   display:none;
   background: rgba(0,0,0,.4);
-  z-index:99;
+  z-index:600;
   position:fixed;
 }
 

--- a/client/page/product_info.html
+++ b/client/page/product_info.html
@@ -171,7 +171,7 @@
   <main class="main product_info">
     <section class="product">
       <h2 class="a11yHidden">탱탱쫄면 상품 상세 페이지</h2>
-      <img src="../../assets/product_detail/tangtang/detail_view.jpg" alt="탱탱쫄면 상품 이미지" class="product__img">
+      <img src="../assets/product_detail/tangtang/detail_view.jpg" alt="탱탱쫄면 상품 이미지" class="product__img">
       <div class="product__info">
         <p class="product__info--delivery">샛별배송</p>
         <h3 class="product__info--name">[풀무원] 탱탱쫄면 (4개입)</h2>
@@ -238,8 +238,8 @@
           총 상품금액: <span>4,980</span>원
         </p>
         <div class="btn-area">
-          <img src="../../assets/icons/Icon/icon-heart-on.png" alt="관심 상품으로 등록되어 있습니다.">
-          <img src="../../assets/icons/Icon/icon-alarm-off.png" alt="해당 상품의 재입고 알림을 받지 않는 상태입니다.">
+          <img src="../assets/icons/Icon/icon-heart-on.png" alt="관심 상품으로 등록되어 있습니다.">
+          <img src="../assets/icons/Icon/icon-alarm-off.png" alt="해당 상품의 재입고 알림을 받지 않는 상태입니다.">
           <p>장바구니 담기</p>
         </div>
       </div>
@@ -252,11 +252,11 @@
     </ul>
     <section class="pd-desc tabpanel is-active" role="tabpanel" id="pd-desc" aria-labelledby="tab__pd-desc">
       <h2 class="a11yHidden">탱탱쫄면 상품 설명</h2>
-      <img src="../../assets/product_detail/tangtang/detail_banner.png" alt="탱탱쫄면 상품 설명">
+      <img src="../assets/product_detail/tangtang/detail_banner.png" alt="탱탱쫄면 상품 설명">
     </section>
     <section class="pd-detail-info tabpanel" role="tabpanel" id="pd-detail-info" aria-labelledby="tab__pd-detail-info">
       <h2 class="a11yHidden">탱탱쫄면 상세 정보</h2>
-      <img src="../../assets/product_detail/tangtang/detail_info.png" alt="탱탱쫄면 상세 정보">
+      <img src="../assets/product_detail/tangtang/detail_info.png" alt="탱탱쫄면 상세 정보">
     </section>
     <!-- PRODUCT-REVIEW : include/product_review.html -->
     <section class="product-review">


### PR DESCRIPTION
## ✅PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/marketkarly-team/marketkarly-client/wiki/github-commit-message-convention
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## ✔️PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] A11Y
- [x] Bugfix
- [ ] Add
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 🔢What is the current behavior?
- review&inquiry 팝업 창의 z-index를 통해 최상단에 배치하였습니다.
- image 경로 수정하였습니다.

Issue Number: #83 

## 🙏Request Code Review